### PR TITLE
SyntaxError fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ module.exports = function lwipify (source, options, callback) {
         };
     }
 
-    callback = callback || () => {};
+    callback = callback || (() => {});
     options = options || {};
     options.source = source;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const isRemote = require("url-remote")
     , path = require('path')
     , lwip = require("lwip2")
     , got = require("got")
+    , noop = require("noop6")
     ;
 
 /**
@@ -31,7 +32,7 @@ module.exports = function lwipify (source, options, callback) {
         };
     }
 
-    callback = callback || (() => {});
+    callback = callback || noop;
     options = options || {};
     options.source = source;
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "got": "^6.1.0",
     "lwip2": "^1.0.0",
+    "noop6": "^1.0.1",
     "url-remote": "^1.1.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
I'm getting a `SyntaxError` with this module. The problem is at L34. The noop arrow function (`() => {}`) gives V8 trouble.

(Note: this only affects v50+ of V8, which is present in the latest Node release (v6))

The fix is to change the line by wrapping the noop in parenthesis:

``` js
callback = callback || (() => {});
```

Not sure why the noop isn't accepted without parenthesis, but this is a pretty simple fix + release for those using the latest Node/V8.
