### PR TITLE
replace lwip library

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url-remote": "^1.1.0"
   },
   "devDependencies": {
-    "lwip": "0.0.9"
+    "@randy.tarampi/lwip": "*"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
lwip fails to build on Node >= 6, so this patch replaces it with a modern, maintained fork.